### PR TITLE
Add support for Free to Play users

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ You can also select a different region - preferably far away from your actual lo
 ## How it works
 
 This extension overwrites the [`fetch`](https://developer.mozilla.org/en-US/docs/Web/API/fetch) method to intercept requests to the Xbox servers.
-When loading [xbox.com/play](https://www.xbox.com/play), a POST request is made to `https://xgpuweb.gssv-play-prod.xboxlive.com/v2/login/user`.
+When loading [xbox.com/play](https://www.xbox.com/play), a POST request is made to `https://xgpuweb.gssv-play-prod.xboxlive.com/v2/login/user` for Game Pass Ultimate users or `https://xgpuwebf2p.gssv...` for Free to Play users.
 The response contains a list of all regions with one of them marked as the default region (shortened):
 
 ```json

--- a/src/content/interceptors/regionInterceptor.ts
+++ b/src/content/interceptors/regionInterceptor.ts
@@ -7,7 +7,7 @@ class RegionInterceptor implements Interceptor {
     method: "POST",
     // @ts-ignore: URLPattern is not known to Typescript yet
     urlPattern: new URLPattern(
-      "https://xgpuweb.gssv-play-prod.xboxlive.com/v2/login/user",
+      "https://xgpuweb(f2p)?.gssv-play-prod.xboxlive.com/v2/login/user",
     ),
   };
 


### PR DESCRIPTION
This PR adds support for Free to Play users.

Xbox Cloud seems to use a different API endpoint to authenticating users that are not subscribed to Game Pass Ultimate.
Without this change, this extension won't work for Free to Play users.