### PR TITLE
no chrome update shaming

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -7,7 +7,7 @@
     "128": "icon.png"
   },
   "homepage_url": "https://github.com/n-thumann/xbox-cloud-server-selector",
-  "minimum_chrome_version": "111",
+  "minimum_chrome_version": "1",
   "action": {
     "default_popup": "popup.html"
   },


### PR DESCRIPTION
if you fill in the blank, i can make another PR or commit like:  `chrome.runtime.onInstalled.addListener(function(installed){if(installed.reason=='install'){if 111 > Number(navigator.userAgent.match(new RegExp(chrome + '/([0-9]+)'))){alert("[Just to make sure:] Some of our features might require chrome version 111+.... _______________________") }`    ( - or rather add it precisely, when that feature is first enabled as indicated by it's button or storage change.)